### PR TITLE
Fix TypeScript build errors: Remove unused variables and imports

### DIFF
--- a/frontend/VitalMedic/src/pages/LandingPage.tsx
+++ b/frontend/VitalMedic/src/pages/LandingPage.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Shield, Clock, Users, CheckCircle, Star, ArrowRight, Phone, Mail, MapPin, Stethoscope, Calendar, FileText } from 'lucide-react';
 
 const LandingPage: React.FC = () => {
-  const navigate = useNavigate();
 
   const handleKeycloakLogin = () => {
     // Redirect to Keycloak authentication

--- a/frontend/VitalMedic/src/pages/patient/Inicio.tsx
+++ b/frontend/VitalMedic/src/pages/patient/Inicio.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Calendar, Clock, User, Phone, MapPin } from 'lucide-react';
 import { useNavigate } from "react-router";
 import Banner from "../../components/ui/Banner";
@@ -31,7 +30,6 @@ const Inicio = () => {
   
   const { 
     nextAppointment, 
-    appointments, 
     loading: appointmentsLoading 
   } = usePatientAppointments(patientId);
   


### PR DESCRIPTION
- Remove unused 'navigate' import and variable from LandingPage.tsx
- Remove unused 'React' import from patient/Inicio.tsx
- Remove unused 'appointments' variable from patient/Inicio.tsx
- Fixes Vercel build errors TS6133 for unused declarations